### PR TITLE
Add API base helper and improve backend logging

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,17 +6,24 @@ import ServerInfo from "./components/ServerInfo";
 import GameModes from "./components/GameModes";
 import Gallery from "./components/Gallery";
 import Footer from "./components/Footer";
+import { getApiBase } from "./lib/api";
 
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-const API = `${BACKEND_URL}/api`;
+const API_BASE = getApiBase();
 
 function App() {
   const testConnection = async () => {
     try {
-      const response = await axios.get(`${API}/`);
+      const response = await axios.get(`${API_BASE}/`);
       console.log("Backend connected:", response.data.message);
     } catch (e) {
       console.error("Backend connection error:", e);
+      console.info("API base attempted:", API_BASE);
+      if (!process.env.REACT_APP_BACKEND_URL) {
+        console.warn(
+          "REACT_APP_BACKEND_URL is not set. Attempted to reach backend via:",
+          API_BASE
+        );
+      }
     }
   };
 

--- a/frontend/src/components/ServerInfo.js
+++ b/frontend/src/components/ServerInfo.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import ServerStatus from "./ServerStatus";
+import { getApiBase } from "../lib/api";
 
 const ServerInfo = () => {
   const [serverStatus, setServerStatus] = useState({
@@ -10,12 +11,11 @@ const ServerInfo = () => {
     playersOnline: 0
   });
 
-  const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-  const API = `${BACKEND_URL}/api`;
+  const API_BASE = getApiBase();
 
   const fetchServerStatus = async () => {
     try {
-      const response = await axios.get(`${API}/server-status`);
+      const response = await axios.get(`${API_BASE}/server-status`);
       setServerStatus({
         version: response.data.version || "1.21.5",
         support: "Java Dan Bedrock",
@@ -24,6 +24,13 @@ const ServerInfo = () => {
       });
     } catch (error) {
       console.error('Failed to fetch server status:', error);
+      console.info('API base attempted:', API_BASE);
+      if (!process.env.REACT_APP_BACKEND_URL) {
+        console.warn(
+          'REACT_APP_BACKEND_URL is not set. Attempted to reach backend via:',
+          API_BASE
+        );
+      }
     }
   };
 

--- a/frontend/src/components/ServerStatus.js
+++ b/frontend/src/components/ServerStatus.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import { getApiBase } from '../lib/api';
 
 const ServerStatus = () => {
   const [serverStatus, setServerStatus] = useState(null);
@@ -7,18 +8,24 @@ const ServerStatus = () => {
   const [error, setError] = useState(null);
   const [lastUpdated, setLastUpdated] = useState(null);
 
-  const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
-  const API = `${BACKEND_URL}/api`;
+  const API_BASE = getApiBase();
 
   const fetchServerStatus = async () => {
     try {
-      const response = await axios.get(`${API}/server-status`);
+      const response = await axios.get(`${API_BASE}/server-status`);
       setServerStatus(response.data);
       setLastUpdated(new Date());
       setError(null);
     } catch (err) {
       setError('Failed to fetch server status');
       console.error('Server status error:', err);
+      console.info('API base attempted:', API_BASE);
+      if (!process.env.REACT_APP_BACKEND_URL) {
+        console.warn(
+          'REACT_APP_BACKEND_URL is not set. Attempted to reach backend via:',
+          API_BASE
+        );
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,16 @@
+export function getApiBase() {
+  const envUrl = process.env.REACT_APP_BACKEND_URL;
+  const trimmedEnvUrl = envUrl && envUrl.trim();
+
+  if (trimmedEnvUrl) {
+    const normalizedEnvUrl = trimmedEnvUrl.replace(/\/$/, "");
+    return `${normalizedEnvUrl}/api`;
+  }
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    const origin = window.location.origin.replace(/\/$/, "");
+    return `${origin}/api`;
+  }
+
+  return "/api";
+}


### PR DESCRIPTION
## Summary
- add a shared getApiBase helper that normalizes the backend URL with fallbacks
- update axios calls in App and server components to rely on the helper
- log the attempted API base when the backend cannot be reached to aid debugging

## Testing
- yarn test --watchAll=false *(fails: unable to download Yarn due to restricted network)*

------
https://chatgpt.com/codex/tasks/task_e_68e077c5847883218ae8d6b4bec5236b